### PR TITLE
fix: let limit and offset use bind parameter

### DIFF
--- a/executor_test.go
+++ b/executor_test.go
@@ -64,8 +64,8 @@ func Test_Executor_Expr(t *testing.T) {
 				).
 				IntoDB().
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM (SELECT * FROM `dict`) AS `a` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT * FROM (SELECT * FROM `dict`) AS `a` LIMIT ?",
 		},
 		{
 			name: "Expr: select *",
@@ -73,8 +73,8 @@ func Test_Executor_Expr(t *testing.T) {
 				SelectExpr().
 				IntoDB().
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT * FROM `dict` LIMIT ?",
 		},
 		{
 			name: "Expr: select field",
@@ -86,8 +86,8 @@ func Test_Executor_Expr(t *testing.T) {
 				).
 				IntoDB().
 				Take(&dummy),
-			wantVars: []any{int64(0)},
-			want:     "SELECT `dict`.`id`,UNIX_TIMESTAMP(`dict`.`created_at`) AS `created_at`,IFNULL(UNIX_TIMESTAMP(`dict`.`created_at`),?) AS `created_at1` FROM `dict` LIMIT 1",
+			wantVars: []any{int64(0), 1},
+			want:     "SELECT `dict`.`id`,UNIX_TIMESTAMP(`dict`.`created_at`) AS `created_at`,IFNULL(UNIX_TIMESTAMP(`dict`.`created_at`),?) AS `created_at1` FROM `dict` LIMIT ?",
 		},
 		{
 			name: "Expr: select * using distinct",
@@ -95,8 +95,8 @@ func Test_Executor_Expr(t *testing.T) {
 				DistinctExpr(xDict.Id).
 				IntoDB().
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT DISTINCT `dict`.`id` FROM `dict` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT DISTINCT `dict`.`id` FROM `dict` LIMIT ?",
 		},
 		{
 			name: "Expr: order",
@@ -104,8 +104,8 @@ func Test_Executor_Expr(t *testing.T) {
 				OrderExpr(xDict.Score).
 				IntoDB().
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` ORDER BY `dict`.`score` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT * FROM `dict` ORDER BY `dict`.`score` LIMIT ?",
 		},
 		{
 			name: "Expr: group",
@@ -113,8 +113,8 @@ func Test_Executor_Expr(t *testing.T) {
 				GroupExpr(xDict.Name).
 				IntoDB().
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` GROUP BY `dict`.`name` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT * FROM `dict` GROUP BY `dict`.`name` LIMIT ?",
 		},
 		{
 			name: "Expr: cross join",
@@ -125,8 +125,8 @@ func Test_Executor_Expr(t *testing.T) {
 				).
 				IntoDB().
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` CROSS JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` CROSS JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` LIMIT ?",
 		},
 		{
 			name: "Expr: cross join X",
@@ -139,8 +139,8 @@ func Test_Executor_Expr(t *testing.T) {
 				).
 				IntoDB().
 				Take(&dummy),
-			wantVars: []any{true},
-			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` CROSS JOIN `dict` `dd` ON `dd`.`id` = `dict`.`pid` AND `dd`.`is_pin` = ? LIMIT 1",
+			wantVars: []any{true, 1},
+			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` CROSS JOIN `dict` `dd` ON `dd`.`id` = `dict`.`pid` AND `dd`.`is_pin` = ? LIMIT ?",
 		},
 		{
 			name: "Expr: inner join",
@@ -148,8 +148,8 @@ func Test_Executor_Expr(t *testing.T) {
 				InnerJoinsExpr(&xDt, xDt.DictId.EqCol(xDict.Id)).
 				IntoDB().
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` INNER JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` INNER JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` LIMIT ?",
 		},
 		{
 			name: "Expr: inner join X",
@@ -157,8 +157,8 @@ func Test_Executor_Expr(t *testing.T) {
 				InnerJoinsXExpr(&xDd, xDd.X_Alias(), xDd.Id.EqCol(xDict.Pid), xDd.IsPin.Eq(true)).
 				IntoDB().
 				Take(&dummy),
-			wantVars: []any{true},
-			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` INNER JOIN `dict` `dd` ON `dd`.`id` = `dict`.`pid` AND `dd`.`is_pin` = ? LIMIT 1",
+			wantVars: []any{true, 1},
+			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` INNER JOIN `dict` `dd` ON `dd`.`id` = `dict`.`pid` AND `dd`.`is_pin` = ? LIMIT ?",
 		},
 		{
 			name: "Expr: left join",
@@ -166,8 +166,8 @@ func Test_Executor_Expr(t *testing.T) {
 				LeftJoinsExpr(&xDt, xDt.DictId.EqCol(xDict.Id)).
 				IntoDB().
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` LEFT JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` LEFT JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` LIMIT ?",
 		},
 		{
 			name: "Expr: left join X",
@@ -175,8 +175,8 @@ func Test_Executor_Expr(t *testing.T) {
 				LeftJoinsXExpr(&xDd, xDd.X_Alias(), xDd.Id.EqCol(xDict.Pid), xDd.IsPin.Eq(true)).
 				IntoDB().
 				Take(&dummy),
-			wantVars: []any{true},
-			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` LEFT JOIN `dict` `dd` ON `dd`.`id` = `dict`.`pid` AND `dd`.`is_pin` = ? LIMIT 1",
+			wantVars: []any{true, 1},
+			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` LEFT JOIN `dict` `dd` ON `dd`.`id` = `dict`.`pid` AND `dd`.`is_pin` = ? LIMIT ?",
 		},
 		{
 			name: "Expr: right join",
@@ -184,8 +184,8 @@ func Test_Executor_Expr(t *testing.T) {
 				RightJoinsExpr(&xDt, xDt.DictId.EqCol(xDict.Id)).
 				IntoDB().
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` RIGHT JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` RIGHT JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` LIMIT ?",
 		},
 		{
 			name: "Expr: right join X",
@@ -193,8 +193,8 @@ func Test_Executor_Expr(t *testing.T) {
 				RightJoinsXExpr(&xDd, xDd.X_Alias(), xDd.Id.EqCol(xDict.Pid), xDd.IsPin.Eq(true)).
 				IntoDB().
 				Take(&dummy),
-			wantVars: []any{true},
-			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` RIGHT JOIN `dict` `dd` ON `dd`.`id` = `dict`.`pid` AND `dd`.`is_pin` = ? LIMIT 1",
+			wantVars: []any{true, 1},
+			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` RIGHT JOIN `dict` `dd` ON `dd`.`id` = `dict`.`pid` AND `dd`.`is_pin` = ? LIMIT ?",
 		},
 		{
 			name: "clause: for update",
@@ -202,8 +202,8 @@ func Test_Executor_Expr(t *testing.T) {
 				LockingUpdate().
 				IntoDB().
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` LIMIT 1 FOR UPDATE",
+			wantVars: []any{1},
+			want:     "SELECT * FROM `dict` LIMIT ? FOR UPDATE",
 		},
 		{
 			name: "clause: for share",
@@ -211,8 +211,8 @@ func Test_Executor_Expr(t *testing.T) {
 				LockingShare().
 				IntoDB().
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` LIMIT 1 FOR SHARE",
+			wantVars: []any{1},
+			want:     "SELECT * FROM `dict` LIMIT ? FOR SHARE",
 		},
 		{
 			name: "clause: pagination",
@@ -220,8 +220,8 @@ func Test_Executor_Expr(t *testing.T) {
 				Pagination(2, 10).
 				IntoDB().
 				Find(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` LIMIT 10 OFFSET 10",
+			wantVars: []any{10, 10},
+			want:     "SELECT * FROM `dict` LIMIT ? OFFSET ?",
 		},
 		{
 			name: "clause: Returning",
@@ -263,8 +263,8 @@ func Test_Executor_SubQuery(t *testing.T) {
 				).
 				IntoDB().
 				Take(&dummy),
-			wantVars: []any{int64(100)},
-			want:     "SELECT * FROM `dict` WHERE `dict`.`id` = (SELECT `dict`.`id` FROM `dict` WHERE `dict`.`pid` = ?) LIMIT 1",
+			wantVars: []any{int64(100), 1},
+			want:     "SELECT * FROM `dict` WHERE `dict`.`id` = (SELECT `dict`.`id` FROM `dict` WHERE `dict`.`pid` = ?) LIMIT ?",
 		},
 		{
 			name: "sub query: IntoExistExpr",

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
-	gorm.io/gorm v1.25.6
+	gorm.io/gorm v1.25.7
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,5 @@ github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 h1:MGwJjxBy0HJshjDNfLsYO8xppfqWlA5ZT9OhtUUhTNw=
 golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
-gorm.io/gorm v1.25.6 h1:V92+vVda1wEISSOMtodHVRcUIOPYa2tgQtyF+DfFx+A=
-gorm.io/gorm v1.25.6/go.mod h1:hbnx/Oo0ChWMn1BIhpy1oYozzpM15i4YPuHDmfYtwg8=
+gorm.io/gorm v1.25.7 h1:VsD6acwRjz2zFxGO50gPO6AkNs7KKnvfzUjHQhZDz/A=
+gorm.io/gorm v1.25.7/go.mod h1:hbnx/Oo0ChWMn1BIhpy1oYozzpM15i4YPuHDmfYtwg8=

--- a/rapier_chains_test.go
+++ b/rapier_chains_test.go
@@ -69,8 +69,8 @@ func Test_Condition_Expr(t *testing.T) {
 				).
 				IntoDB().
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT `dict`.`id` FROM `dict` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT `dict`.`id` FROM `dict` LIMIT ?",
 		},
 		{
 			name: "Expr: select *",
@@ -82,8 +82,8 @@ func Test_Condition_Expr(t *testing.T) {
 				).
 				IntoDB().
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT * FROM `dict` LIMIT ?",
 		},
 		{
 			name: "Expr: select field",
@@ -99,8 +99,8 @@ func Test_Condition_Expr(t *testing.T) {
 				).
 				IntoDB().
 				Take(&dummy),
-			wantVars: []any{int64(0)},
-			want:     "SELECT `dict`.`id`,UNIX_TIMESTAMP(`dict`.`created_at`) AS `created_at`,IFNULL(UNIX_TIMESTAMP(`dict`.`created_at`),?) AS `created_at1` FROM `dict` LIMIT 1",
+			wantVars: []any{int64(0), 1},
+			want:     "SELECT `dict`.`id`,UNIX_TIMESTAMP(`dict`.`created_at`) AS `created_at`,IFNULL(UNIX_TIMESTAMP(`dict`.`created_at`),?) AS `created_at1` FROM `dict` LIMIT ?",
 		},
 		{
 			name: "Expr: select * using distinct",
@@ -112,8 +112,8 @@ func Test_Condition_Expr(t *testing.T) {
 				).
 				IntoDB().
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT DISTINCT `dict`.`id` FROM `dict` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT DISTINCT `dict`.`id` FROM `dict` LIMIT ?",
 		},
 		{
 			name: "Expr: order",
@@ -125,8 +125,8 @@ func Test_Condition_Expr(t *testing.T) {
 				).
 				IntoDB().
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` ORDER BY `dict`.`score` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT * FROM `dict` ORDER BY `dict`.`score` LIMIT ?",
 		},
 		{
 			name: "Expr: group",
@@ -138,8 +138,8 @@ func Test_Condition_Expr(t *testing.T) {
 				).
 				IntoDB().
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` GROUP BY `dict`.`name` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT * FROM `dict` GROUP BY `dict`.`name` LIMIT ?",
 		},
 		{
 			name: "Expr: cross join",
@@ -154,8 +154,8 @@ func Test_Condition_Expr(t *testing.T) {
 				).
 				IntoDB().
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` CROSS JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` CROSS JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` LIMIT ?",
 		},
 		{
 			name: "Expr: cross join X",
@@ -172,8 +172,8 @@ func Test_Condition_Expr(t *testing.T) {
 				).
 				IntoDB().
 				Take(&dummy),
-			wantVars: []any{true},
-			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` CROSS JOIN `dict` `dd` ON `dd`.`id` = `dict`.`pid` AND `dd`.`is_pin` = ? LIMIT 1",
+			wantVars: []any{true, 1},
+			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` CROSS JOIN `dict` `dd` ON `dd`.`id` = `dict`.`pid` AND `dd`.`is_pin` = ? LIMIT ?",
 		},
 		{
 			name: "Expr: inner join",
@@ -185,8 +185,8 @@ func Test_Condition_Expr(t *testing.T) {
 				).
 				IntoDB().
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` INNER JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` INNER JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` LIMIT ?",
 		},
 		{
 			name: "Expr: inner join X",
@@ -198,8 +198,8 @@ func Test_Condition_Expr(t *testing.T) {
 				).
 				IntoDB().
 				Take(&dummy),
-			wantVars: []any{true},
-			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` INNER JOIN `dict` `dd` ON `dd`.`id` = `dict`.`pid` AND `dd`.`is_pin` = ? LIMIT 1",
+			wantVars: []any{true, 1},
+			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` INNER JOIN `dict` `dd` ON `dd`.`id` = `dict`.`pid` AND `dd`.`is_pin` = ? LIMIT ?",
 		},
 		{
 			name: "Expr: left join",
@@ -211,8 +211,8 @@ func Test_Condition_Expr(t *testing.T) {
 				).
 				IntoDB().
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` LEFT JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` LEFT JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` LIMIT ?",
 		},
 		{
 			name: "Expr: left join X",
@@ -224,8 +224,8 @@ func Test_Condition_Expr(t *testing.T) {
 				).
 				IntoDB().
 				Take(&dummy),
-			wantVars: []any{true},
-			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` LEFT JOIN `dict` `dd` ON `dd`.`id` = `dict`.`pid` AND `dd`.`is_pin` = ? LIMIT 1",
+			wantVars: []any{true, 1},
+			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` LEFT JOIN `dict` `dd` ON `dd`.`id` = `dict`.`pid` AND `dd`.`is_pin` = ? LIMIT ?",
 		},
 		{
 			name: "Expr: right join",
@@ -237,8 +237,8 @@ func Test_Condition_Expr(t *testing.T) {
 				).
 				IntoDB().
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` RIGHT JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` RIGHT JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` LIMIT ?",
 		},
 		{
 			name: "Expr: right join X",
@@ -250,8 +250,8 @@ func Test_Condition_Expr(t *testing.T) {
 				).
 				IntoDB().
 				Take(&dummy),
-			wantVars: []any{true},
-			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` RIGHT JOIN `dict` `dd` ON `dd`.`id` = `dict`.`pid` AND `dd`.`is_pin` = ? LIMIT 1",
+			wantVars: []any{true, 1},
+			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` RIGHT JOIN `dict` `dd` ON `dd`.`id` = `dict`.`pid` AND `dd`.`is_pin` = ? LIMIT ?",
 		},
 		{
 			name: "clause: for update",
@@ -263,8 +263,8 @@ func Test_Condition_Expr(t *testing.T) {
 				).
 				IntoDB().
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` LIMIT 1 FOR UPDATE",
+			wantVars: []any{1},
+			want:     "SELECT * FROM `dict` LIMIT ? FOR UPDATE",
 		},
 		{
 			name: "clause: for share",
@@ -276,8 +276,8 @@ func Test_Condition_Expr(t *testing.T) {
 				).
 				IntoDB().
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` LIMIT 1 FOR SHARE",
+			wantVars: []any{1},
+			want:     "SELECT * FROM `dict` LIMIT ? FOR SHARE",
 		},
 		{
 			name: "clause: pagination",
@@ -289,8 +289,8 @@ func Test_Condition_Expr(t *testing.T) {
 				).
 				IntoDB().
 				Find(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` LIMIT 10 OFFSET 10",
+			wantVars: []any{10, 10},
+			want:     "SELECT * FROM `dict` LIMIT ? OFFSET ?",
 		},
 	}
 	for _, tt := range tests {

--- a/rapier_join_test.go
+++ b/rapier_join_test.go
@@ -24,8 +24,8 @@ func Test_Joins(t *testing.T) {
 					InnerJoinsExpr(&xDictItem),
 				).
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT * FROM `dict` LIMIT ?",
 		},
 		{
 			name: "cross join",
@@ -34,8 +34,8 @@ func Test_Joins(t *testing.T) {
 					CrossJoinsExpr(&xDictItem, xDictItem.DictId.EqCol(xDict.Id), xDictItem.IsEnabled.Eq(true)),
 				).
 				Take(&dummy),
-			wantVars: []any{true},
-			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` CROSS JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` AND `dict_item`.`is_enabled` = ? LIMIT 1",
+			wantVars: []any{true, 1},
+			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` CROSS JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` AND `dict_item`.`is_enabled` = ? LIMIT ?",
 		},
 		{
 			name: "inner join",
@@ -44,8 +44,8 @@ func Test_Joins(t *testing.T) {
 					InnerJoinsExpr(&xDictItem, xDictItem.DictId.EqCol(xDict.Id), xDictItem.IsEnabled.Eq(true)),
 				).
 				Take(&dummy),
-			wantVars: []any{true},
-			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` INNER JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` AND `dict_item`.`is_enabled` = ? LIMIT 1",
+			wantVars: []any{true, 1},
+			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` INNER JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` AND `dict_item`.`is_enabled` = ? LIMIT ?",
 		},
 		{
 			name: "left join",
@@ -54,8 +54,8 @@ func Test_Joins(t *testing.T) {
 					LeftJoinsExpr(&xDictItem, xDictItem.DictId.EqCol(xDict.Id), xDictItem.IsEnabled.Eq(true)),
 				).
 				Take(&dummy),
-			wantVars: []any{true},
-			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` LEFT JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` AND `dict_item`.`is_enabled` = ? LIMIT 1",
+			wantVars: []any{true, 1},
+			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` LEFT JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` AND `dict_item`.`is_enabled` = ? LIMIT ?",
 		},
 		{
 			name: "right join",
@@ -64,8 +64,8 @@ func Test_Joins(t *testing.T) {
 					RightJoinsExpr(&xDictItem, xDictItem.DictId.EqCol(xDict.Id), xDictItem.IsEnabled.Eq(true)),
 				).
 				Take(&dummy),
-			wantVars: []any{true},
-			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` RIGHT JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` AND `dict_item`.`is_enabled` = ? LIMIT 1",
+			wantVars: []any{true, 1},
+			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` RIGHT JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` AND `dict_item`.`is_enabled` = ? LIMIT ?",
 		},
 		{
 			name: "inner join - multiple",
@@ -75,8 +75,8 @@ func Test_Joins(t *testing.T) {
 					InnerJoinsXExpr(&xDi, xDi.X_Alias(), xDi.IsEnabled.Eq(true)),
 				).
 				Take(&dummy),
-			wantVars: []any{true},
-			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` INNER JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` INNER JOIN `dict_item` `di` ON `di`.`is_enabled` = ? LIMIT 1",
+			wantVars: []any{true, 1},
+			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort`,`dict`.`created_at` FROM `dict` INNER JOIN `dict_item` ON `dict_item`.`dict_id` = `dict`.`id` INNER JOIN `dict_item` `di` ON `di`.`is_enabled` = ? LIMIT ?",
 		},
 	}
 	for _, tt := range tests {

--- a/rapier_paginate_test.go
+++ b/rapier_paginate_test.go
@@ -17,32 +17,32 @@ func Test_Paginate(t *testing.T) {
 			{
 				name:     "in range",
 				db:       newDb().Model(Dict{}).Clauses(Paginate(2, 10)).Find([]Dict{}),
-				wantVars: nil,
-				want:     "SELECT * FROM `dict` LIMIT 10 OFFSET 10",
+				wantVars: []any{10, 10},
+				want:     "SELECT * FROM `dict` LIMIT ? OFFSET ?",
 			},
 			{
 				name:     "page < 1",
 				db:       newDb().Model(Dict{}).Clauses(Paginate(0, 10)).Find([]Dict{}),
-				wantVars: nil,
-				want:     "SELECT * FROM `dict` LIMIT 10",
+				wantVars: []any{10},
+				want:     "SELECT * FROM `dict` LIMIT ?",
 			},
 			{
 				name:     "perPage < 1",
 				db:       newDb().Model(Dict{}).Clauses(Paginate(1, 0)).Find([]Dict{}),
-				wantVars: nil,
-				want:     "SELECT * FROM `dict` LIMIT 50",
+				wantVars: []any{50},
+				want:     "SELECT * FROM `dict` LIMIT ?",
 			},
 			{
 				name:     "perPage > DefaultMaxPerPage",
 				db:       newDb().Model(Dict{}).Clauses(Paginate(1, DefaultMaxPerPage+1)).Find([]Dict{}),
-				wantVars: nil,
-				want:     "SELECT * FROM `dict` LIMIT 500",
+				wantVars: []any{500},
+				want:     "SELECT * FROM `dict` LIMIT ?",
 			},
 			{
 				name:     "customer perPage > maxPerPage",
 				db:       newDb().Model(Dict{}).Clauses(Paginate(1, 201, 200)).Find([]Dict{}),
-				wantVars: nil,
-				want:     "SELECT * FROM `dict` LIMIT 200",
+				wantVars: []any{200},
+				want:     "SELECT * FROM `dict` LIMIT ?",
 			},
 		}
 		for _, tt := range tests {
@@ -62,26 +62,26 @@ func Test_Paginate(t *testing.T) {
 			{
 				name:     "in range",
 				db:       newDb().Model(Dict{}).Scopes(Pagination(2, 10)).Find([]Dict{}),
-				wantVars: nil,
-				want:     "SELECT * FROM `dict` LIMIT 10 OFFSET 10",
+				wantVars: []any{10, 10},
+				want:     "SELECT * FROM `dict` LIMIT ? OFFSET ?",
 			},
 			{
 				name:     "page < 1",
 				db:       newDb().Model(Dict{}).Scopes(Pagination(0, 10)).Find([]Dict{}),
-				wantVars: nil,
-				want:     "SELECT * FROM `dict` LIMIT 10",
+				wantVars: []any{10},
+				want:     "SELECT * FROM `dict` LIMIT ?",
 			},
 			{
 				name:     "perPage < 1",
 				db:       newDb().Model(Dict{}).Scopes(Pagination(1, 0)).Find([]Dict{}),
-				wantVars: nil,
-				want:     "SELECT * FROM `dict` LIMIT 50",
+				wantVars: []any{50},
+				want:     "SELECT * FROM `dict` LIMIT ?",
 			},
 			{
 				name:     "perPage > DefaultMaxPerPage",
 				db:       newDb().Model(Dict{}).Scopes(Pagination(1, DefaultMaxPerPage+1)).Find([]Dict{}),
-				wantVars: nil,
-				want:     "SELECT * FROM `dict` LIMIT 500",
+				wantVars: []any{500},
+				want:     "SELECT * FROM `dict` LIMIT ?",
 			},
 		}
 		for _, tt := range tests {

--- a/rapier_test.go
+++ b/rapier_test.go
@@ -145,8 +145,8 @@ func Test_Table(t *testing.T) {
 					TableExpr(),
 				).
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT * FROM `dict` LIMIT ?",
 		},
 		{
 			name: "single table",
@@ -161,8 +161,8 @@ func Test_Table(t *testing.T) {
 					),
 				).
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM (SELECT * FROM `dict`) AS `a` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT * FROM (SELECT * FROM `dict`) AS `a` LIMIT ?",
 		},
 		{
 			name: "multi table",
@@ -182,8 +182,8 @@ func Test_Table(t *testing.T) {
 					),
 				).
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM (SELECT * FROM `dict`) AS `a`, (SELECT * FROM `dict`) AS `b` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT * FROM (SELECT * FROM `dict`) AS `a`, (SELECT * FROM `dict`) AS `b` LIMIT ?",
 		},
 	}
 	for _, tt := range tests {
@@ -209,8 +209,8 @@ func Test_Select(t *testing.T) {
 					SelectExpr(),
 				).
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT * FROM `dict` LIMIT ?",
 		},
 		{
 			name: "select field",
@@ -223,8 +223,8 @@ func Test_Select(t *testing.T) {
 					),
 				).
 				Take(&dummy),
-			wantVars: []any{int64(0)},
-			want:     "SELECT `dict`.`id`,UNIX_TIMESTAMP(`dict`.`created_at`) AS `created_at`,IFNULL(UNIX_TIMESTAMP(`dict`.`created_at`),?) AS `created_at1` FROM `dict` LIMIT 1",
+			wantVars: []any{int64(0), 1},
+			want:     "SELECT `dict`.`id`,UNIX_TIMESTAMP(`dict`.`created_at`) AS `created_at`,IFNULL(UNIX_TIMESTAMP(`dict`.`created_at`),?) AS `created_at1` FROM `dict` LIMIT ?",
 		},
 		{
 			name: "select field where",
@@ -234,8 +234,8 @@ func Test_Select(t *testing.T) {
 				).
 				Where(xDict.Name.Eq(""), xDict.IsPin.Is(true)).
 				Take(&dummy),
-			wantVars: []any{"", true},
-			want:     "SELECT `dict`.`id`,`dict`.`score` FROM `dict` WHERE `dict`.`name` = ? AND `dict`.`is_pin` = ? LIMIT 1",
+			wantVars: []any{"", true, 1},
+			want:     "SELECT `dict`.`id`,`dict`.`score` FROM `dict` WHERE `dict`.`name` = ? AND `dict`.`is_pin` = ? LIMIT ?",
 		},
 		{
 			name: "select 1",
@@ -244,8 +244,8 @@ func Test_Select(t *testing.T) {
 					SelectExpr(One),
 				).
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT 1 FROM `dict` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT 1 FROM `dict` LIMIT ?",
 		},
 		{
 			name: "select COUNT(1)",
@@ -254,8 +254,8 @@ func Test_Select(t *testing.T) {
 					SelectExpr(One.Count()),
 				).
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT COUNT(1) FROM `dict` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT COUNT(1) FROM `dict` LIMIT ?",
 		},
 		{
 			name: "select COUNT(*)",
@@ -264,8 +264,8 @@ func Test_Select(t *testing.T) {
 					SelectExpr(Star.Count()),
 				).
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT COUNT(*) FROM `dict` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT COUNT(*) FROM `dict` LIMIT ?",
 		},
 		{
 			name: "select AVG(field)",
@@ -274,8 +274,8 @@ func Test_Select(t *testing.T) {
 					SelectExpr(xDict.Score.Avg()),
 				).
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT AVG(`dict`.`score`) FROM `dict` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT AVG(`dict`.`score`) FROM `dict` LIMIT ?",
 		},
 		{
 			name: "update with select field",
@@ -318,8 +318,8 @@ func Test_Omit(t *testing.T) {
 					OmitExpr(),
 				).
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT * FROM `dict` LIMIT ?",
 		},
 		{
 			name: "omit field",
@@ -330,8 +330,8 @@ func Test_Omit(t *testing.T) {
 					),
 				).
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort` FROM `dict` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`score`,`dict`.`is_pin`,`dict`.`sort` FROM `dict` LIMIT ?",
 		},
 		{
 			name: "omit more fields",
@@ -343,8 +343,8 @@ func Test_Omit(t *testing.T) {
 					),
 				).
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`is_pin`,`dict`.`sort` FROM `dict` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT `dict`.`id`,`dict`.`pid`,`dict`.`name`,`dict`.`is_pin`,`dict`.`sort` FROM `dict` LIMIT ?",
 		},
 	}
 	for _, tt := range tests {
@@ -369,16 +369,16 @@ func Test_Distinct(t *testing.T) {
 					SelectExpr(xDict.Id),
 				).
 				Take(&Dict{}),
-			wantVars: nil,
-			want:     "SELECT DISTINCT `dict`.`id` FROM `dict` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT DISTINCT `dict`.`id` FROM `dict` LIMIT ?",
 		},
 		{
 			name: "distinct field",
 			db: newDb().Model(&Dict{}).
 				Scopes(DistinctExpr(xDict.Id)).
 				Take(&Dict{}),
-			wantVars: nil,
-			want:     "SELECT DISTINCT `dict`.`id` FROM `dict` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT DISTINCT `dict`.`id` FROM `dict` LIMIT ?",
 		},
 	}
 	for _, tt := range tests {
@@ -404,8 +404,8 @@ func Test_Order(t *testing.T) {
 					OrderExpr(),
 				).
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT * FROM `dict` LIMIT ?",
 		},
 		{
 			name: "",
@@ -414,8 +414,8 @@ func Test_Order(t *testing.T) {
 					OrderExpr(xDict.Score),
 				).
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` ORDER BY `dict`.`score` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT * FROM `dict` ORDER BY `dict`.`score` LIMIT ?",
 		},
 		{
 			name: "",
@@ -424,8 +424,8 @@ func Test_Order(t *testing.T) {
 					OrderExpr(xDict.Score.Desc()),
 				).
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` ORDER BY `dict`.`score` DESC LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT * FROM `dict` ORDER BY `dict`.`score` DESC LIMIT ?",
 		},
 		{
 			name: "",
@@ -434,8 +434,8 @@ func Test_Order(t *testing.T) {
 					OrderExpr(xDict.Score.Desc(), xDict.Name),
 				).
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` ORDER BY `dict`.`score` DESC,`dict`.`name` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT * FROM `dict` ORDER BY `dict`.`score` DESC,`dict`.`name` LIMIT ?",
 		},
 	}
 	for _, tt := range tests {
@@ -461,8 +461,8 @@ func Test_Group(t *testing.T) {
 					GroupExpr(),
 				).
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT * FROM `dict` LIMIT ?",
 		},
 		{
 			name: "",
@@ -471,8 +471,8 @@ func Test_Group(t *testing.T) {
 					GroupExpr(xDict.Name),
 				).
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` GROUP BY `dict`.`name` LIMIT 1",
+			wantVars: []any{1},
+			want:     "SELECT * FROM `dict` GROUP BY `dict`.`name` LIMIT ?",
 		},
 		{
 			name: "",
@@ -483,8 +483,8 @@ func Test_Group(t *testing.T) {
 				).
 				Having(xDict.Score.Sum().Gt(100)).
 				Take(&dummy),
-			wantVars: []any{float64(100)},
-			want:     "SELECT SUM(`dict`.`score`) FROM `dict` GROUP BY `dict`.`name` HAVING SUM(`dict`.`score`) > ? LIMIT 1",
+			wantVars: []any{float64(100), 1},
+			want:     "SELECT SUM(`dict`.`score`) FROM `dict` GROUP BY `dict`.`name` HAVING SUM(`dict`.`score`) > ? LIMIT ?",
 		},
 	}
 	for _, tt := range tests {
@@ -511,8 +511,8 @@ func Test_Locking(t *testing.T) {
 					LockingUpdate(),
 				).
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` LIMIT 1 FOR UPDATE",
+			wantVars: []any{1},
+			want:     "SELECT * FROM `dict` LIMIT ? FOR UPDATE",
 		},
 		{
 			name: "",
@@ -522,8 +522,8 @@ func Test_Locking(t *testing.T) {
 					LockingShare(),
 				).
 				Take(&dummy),
-			wantVars: nil,
-			want:     "SELECT * FROM `dict` LIMIT 1 FOR SHARE",
+			wantVars: []any{1},
+			want:     "SELECT * FROM `dict` LIMIT ? FOR SHARE",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
fix let limit and offset use bind parameter from [gorm](https://github.com/go-gorm/gorm) issue <a href="https://redirect.github.com/go-gorm/gorm/issues/6806">#6806</a> cause test failure.